### PR TITLE
PUT a tree of Turtle files into a repository.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,36 @@
         <version>${logback.version}</version>
       </dependency>
   </dependencies>
+  
+  <profiles>
+    <profile>
+      <id>resourceimport</id>
+      <build>
+        <resources>
+          <resource>
+            <directory>src/main/resources</directory>
+          </resource>
+        </resources>
+        <plugins>    
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>1.2.1</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>java</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <mainClass>org.fcrepo.repository.FedoraResourceImport</mainClass>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
   <build>
     <resources>

--- a/src/main/java/org/fcrepo/repository/FedoraResourceImport.java
+++ b/src/main/java/org/fcrepo/repository/FedoraResourceImport.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2015 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.repository;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.slf4j.Logger;
+
+/**
+ * Tool to load a directory tree of Turtle RDF files into a repository.
+ *
+ * @author Peter Eichman
+ * @since 2015-09-25
+ */
+public class FedoraResourceImport {
+    private static final Logger LOGGER = getLogger(FedoraResourceImport.class);
+
+    /**
+     * Upload a directory tree of Turtle files into a repository. The repository base URL passed in using the
+     * fcrepo.url system property (default "http://localhost:8080/rest/"), and the directory to scan for Turtle files
+     * is given in the resources.dir system property (default "." for the current directory).
+     *
+     * @param args
+     */
+    public static void main(final String[] args) {
+
+        final String fcrepoUrl = System.getProperty("fcrepo.url", "http://localhost:8080/rest/");
+        final String resourcesDir = System.getProperty("resources.dir", ".");
+
+        final File dir = new File(resourcesDir);
+
+        LOGGER.info("fcrepoUrl:" + fcrepoUrl);
+        LOGGER.info("resources dir:" + dir.getAbsolutePath());
+
+        final Path filesRoot = Paths.get(resourcesDir);
+        final ResourcePutter putter = new ResourcePutter(URI.create(fcrepoUrl));
+        final FileFinder finder = new FileFinder(filesRoot, putter);
+        try {
+            Files.walkFileTree(filesRoot, finder);
+        } catch (final IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/org/fcrepo/repository/FileFinder.java
+++ b/src/main/java/org/fcrepo/repository/FileFinder.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2015 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.repository;
+
+import static java.nio.file.FileVisitResult.CONTINUE;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.nio.charset.Charset;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+import org.apache.http.entity.FileEntity;
+import org.apache.http.entity.StringEntity;
+import org.slf4j.Logger;
+
+/**
+ * File visitor that looks for Turtle files (.ttl extension) and uploads them to a repository using a ResourcePutter
+ * object.
+ *
+ * @author Peter Eichman
+ * @since 2015-09-25
+ */
+public class FileFinder extends SimpleFileVisitor<Path> {
+
+    private static final Logger LOGGER = getLogger(FileFinder.class);
+
+    private final Path root;
+
+    private final ResourcePutter putter;
+
+    private static StringEntity emptyEntity = new StringEntity("", Charset.forName("UTF-8"));
+
+    public FileFinder(final Path root, final ResourcePutter putter) {
+        this.root = root;
+        this.putter = putter;
+    }
+
+    /**
+     * For each file with the ".ttl" extension, if it is not also a dotfile or named "_.ttl", send its contents in a
+     * PUT request to a URI constructed by removing the ".ttl" extension from the filename. So, for example, a file
+     * named "collection/23/data.ttl" is uploaded to the relative URI "collection/23/data".
+     */
+    @Override
+    public FileVisitResult visitFile(final Path file,
+            final BasicFileAttributes attrs) {
+
+        final String filename = file.getFileName().toString();
+
+        if (filename.endsWith(".ttl") && !filename.startsWith(".") && !filename.equals("_.ttl")) {
+            // file is not hidden ("dotfile") or the special "_.ttl" that represents the container
+            final String uriRef = root.relativize(file).toString().replaceAll("\\.ttl$", "");
+            LOGGER.info("Creating {} from {}", uriRef, filename);
+            putter.put(uriRef, new FileEntity(file.toFile()));
+        }
+
+        return CONTINUE;
+    }
+
+    /**
+     * For each directory, if there is a file named "_.ttl", use that as the Turtle representation of the container
+     * corresponding to this directory. Otherwise, use an empty entity to force creation of a container.
+     */
+    @Override
+    public FileVisitResult preVisitDirectory(final Path dir,
+            final BasicFileAttributes attrs) {
+
+        final String uriRef = root.relativize(dir).toString();
+        LOGGER.info("Creating container " + uriRef);
+
+        final Path dirFile = Paths.get(dir.toString(), "_.ttl");
+        if (Files.exists(dirFile)) {
+            putter.put(uriRef, new FileEntity(dirFile.toFile()));
+        } else {
+            putter.put(uriRef, emptyEntity);
+        }
+        return CONTINUE;
+    }
+
+}

--- a/src/main/java/org/fcrepo/repository/ResourcePutter.java
+++ b/src/main/java/org/fcrepo/repository/ResourcePutter.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2015 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.repository;
+
+import static java.lang.Integer.MAX_VALUE;
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.net.URI;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.slf4j.Logger;
+
+/**
+ * Uses an HTTP client configured with a repository base URI to PUT resources with a given path and content.
+ *
+ * @author Peter Eichman
+ * @since 2015-09-25
+ */
+public class ResourcePutter {
+
+    private static final Logger LOGGER = getLogger(ResourcePutter.class);
+
+    private final HttpClient httpClient = HttpClientBuilder.create().setMaxConnPerRoute(MAX_VALUE)
+            .setMaxConnTotal(MAX_VALUE).build();
+
+    private final URI baseUrl;
+
+    /**
+     * The base URI is given in baseUrl. It should end with a "/" for relative URI refs to resolve as expected.
+     *
+     * @param baseUrl
+     */
+    public ResourcePutter(final URI baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    /**
+     * Issues a PUT request to a URI constructed from the baseUrl plus the given uriRef with the entity as the content
+     * of that request. The Content-Type header is always forced to text/turtle.
+     *
+     * @param uriRef relative path for the uploaded resource
+     * @param entity content of the resource
+     * @return true on success, false on failure
+     */
+    public boolean put(final String uriRef, final HttpEntity entity) {
+        final URI requestURI = baseUrl.resolve(uriRef);
+        final HttpPut put = new HttpPut(requestURI);
+        put.setEntity(entity);
+        put.setHeader("Content-Type", "text/turtle");
+        HttpResponse res;
+        try {
+            res = httpClient.execute(put);
+            LOGGER.debug("URL:" + requestURI);
+            LOGGER.debug("Response:" + res.toString());
+            return res.getStatusLine().getStatusCode() == CREATED.getStatusCode();
+        } catch (final Exception e) {
+            LOGGER.warn("Failed to PUT " + requestURI);
+            e.printStackTrace();
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Creates a container for each directory it finds, and PUTs the contents of each *.ttl file it finds to the appropriate location. A special filename of "_.ttl" is used to specify additional properties to be specified for a container.

To run, use the resourceimport profile in the POM, and specify fcrepo.url and resources.dir system properties.

Issue: https://jira.duraspace.org/browse/FCREPO-1736